### PR TITLE
fix: enhance chatbot to handle general inquiries and specific keywords

### DIFF
--- a/frontend/src/components/ChatAssistant.js
+++ b/frontend/src/components/ChatAssistant.js
@@ -46,6 +46,27 @@ const ChatAssistant = () => {
             return "¡Hola! ¿Buscas algún especialista en particular o tienes alguna duda sobre nuestros servicios?";
         }
 
+        // Consultas generales
+        if (lowerQuery.match(/duda|consulta|pregunta/)) {
+            return "¡Claro! Dime cuál es tu duda y trataré de ayudarte. Puedes preguntarme sobre especialidades, médicos, horarios, obras sociales o cómo sacar un turno.";
+        }
+
+        // Listado de especialidades
+        if (lowerQuery.includes('especialidad')) {
+            const specialties = [...new Set(DOCTORS.map(d => d.specialty))];
+            return `Nuestras especialidades son: ${specialties.join(', ')}. ¿Te interesa alguna en particular?`;
+        }
+
+        // Listado de médicos general
+        if (lowerQuery.includes('medico') || lowerQuery.includes('doctor')) {
+            return "Contamos con especialistas en Cardiología, Pediatría, Dermatología, Traumatología, Oftalmología, Ginecología y Medicina General. ¿Buscas alguno en especial?";
+        }
+
+        // Horarios generales
+        if (lowerQuery.includes('horario') || lowerQuery.includes('hora')) {
+            return "Nuestros médicos atienden en distintos horarios, generalmente entre las 8:00 y las 20:00. Si buscas un especialista en particular, puedo decirte sus horarios específicos.";
+        }
+
         // Especialidades
         if (lowerQuery.includes('cardiolog') || lowerQuery.includes('corazon')) {
             const cardios = DOCTORS.filter(d => d.specialty === 'Cardiología');

--- a/frontend/src/components/ChatAssistant.test.js
+++ b/frontend/src/components/ChatAssistant.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import ChatAssistant from './ChatAssistant';
+
+// Mock scrollIntoView
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+test('ChatAssistant responds to "Tengo una duda" with helpful message', async () => {
+  jest.useFakeTimers();
+  render(<ChatAssistant />);
+
+  // Open chat
+  // The toggle button is the one visible initially.
+  // It has a MessageCircle icon.
+  const toggleButtons = screen.getAllByRole('button');
+  fireEvent.click(toggleButtons[0]);
+
+  // Find input
+  const input = screen.getByPlaceholderText('Escribe tu consulta...');
+
+  // Send "Tengo una duda"
+  fireEvent.change(input, { target: { value: 'Tengo una duda' } });
+  fireEvent.submit(input.closest('form'));
+
+  // Fast-forward time for bot response
+  act(() => {
+    jest.advanceTimersByTime(1500);
+  });
+
+  // Verify we get the specific helpful response
+  await waitFor(() => {
+    const response = screen.queryByText(/Dime cuál es tu duda y trataré de ayudarte/i);
+    // This should fail initially because the code currently returns the default error message
+    expect(response).toBeInTheDocument();
+  });
+});
+
+test('ChatAssistant lists specialties when asked', async () => {
+    jest.useFakeTimers();
+    render(<ChatAssistant />);
+
+    const toggleButtons = screen.getAllByRole('button');
+    fireEvent.click(toggleButtons[0]);
+
+    const input = screen.getByPlaceholderText('Escribe tu consulta...');
+
+    fireEvent.change(input, { target: { value: 'cuales son las especialidades' } });
+    fireEvent.submit(input.closest('form'));
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    await waitFor(() => {
+      // Should list Cardiología, Pediatría, etc.
+      expect(screen.queryByText(/Cardiología/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Pediatría/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Dermatología/i)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
- Update `ChatAssistant.js` to handle queries containing "duda", "consulta", "pregunta".
- Add handlers for "especialidades", "medicos", and "horarios".
- Add unit tests in `ChatAssistant.test.js`.